### PR TITLE
Fix broken links in comm docs

### DIFF
--- a/docs/api/comm/api_comm.md
+++ b/docs/api/comm/api_comm.md
@@ -82,9 +82,9 @@ classDiagram
     }
     class CommIoType {
         <<enumeration>>
-        +COMM_IO_TYPE_TCP
-        +COMM_IO_TYPE_UDP
-        +COMM_IO_TYPE_NUM
+        +TCP
+        +UDP
+        +NUM
     }
 
     ICommServer ..> ICommIO

--- a/docs/api/comm/client/api_comm_client.md
+++ b/docs/api/comm/client/api_comm_client.md
@@ -173,6 +173,5 @@ int main() {
 
 ### 関連ヘッダ
 - [comm.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm.hpp)
-- [comm/icomm_connector.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm/icomm_connector.hpp)
 
 

--- a/docs/api/comm/client/api_comm_client_propmt.md
+++ b/docs/api/comm/client/api_comm_client_propmt.md
@@ -21,7 +21,6 @@ std::shared_ptr<ICommIO> client_open(ICommEndpointType *src, ICommEndpointType *
   - [api-template.md](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/templates/api-template.md)
 - ヘッダ情報
   - [comm.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm.hpp)
-  - [comm/icomm_connector.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm/icomm_connector.hpp)
 
 ## タスク
 - ICommClient の API仕様書をAPI仕様書のテンプレートの書式に従って作成してください。

--- a/docs/api/comm/io/api_comm_io.md
+++ b/docs/api/comm/io/api_comm_io.md
@@ -197,5 +197,4 @@ int main() {
 
 ### 関連ヘッダ
 - [comm.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm.hpp)
-- [comm/icomm_connector.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm/icomm_connector.hpp)
 

--- a/docs/api/comm/io/api_comm_io_prompt.md
+++ b/docs/api/comm/io/api_comm_io_prompt.md
@@ -27,7 +27,6 @@
   - [api-template.md](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/templates/api-template.md)
 - ヘッダ情報
   - [comm.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm.hpp)
-  - [comm/icomm_connector.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm/icomm_connector.hpp)
 
 ## タスク
 - ICommIO の API仕様書をAPI仕様書のテンプレートの書式に従って作成してください。

--- a/docs/api/comm/server/api_comm_server.md
+++ b/docs/api/comm/server/api_comm_server.md
@@ -163,6 +163,5 @@ int main() {
 
 ### 関連ヘッダ
 - [comm.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm.hpp)
-- [comm/icomm_connector.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm/icomm_connector.hpp)
 
 

--- a/docs/api/comm/server/api_comm_server_propmt.md
+++ b/docs/api/comm/server/api_comm_server_propmt.md
@@ -21,7 +21,6 @@ std::shared_ptr<ICommIO> server_open(ICommEndpointType *endpoint) = 0;
   - [api-template.md](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/templates/api-template.md)
 - ヘッダ情報
   - [comm.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm.hpp)
-  - [comm/icomm_connector.hpp](https://github.com/toppers/hakoniwa-drone-core/blob/main/include/comm/icomm_connector.hpp)
 
 ## タスク
 - ICommServer の API仕様書をAPI仕様書のテンプレートの書式に従って作成してください。


### PR DESCRIPTION
## Summary
- update enumeration names in comm API docs
- remove obsolete `icomm_connector.hpp` references from comm documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ac66c4cc832291acbf97331d8ba6