### PR TITLE
Add Mavlink test specs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,5 +28,6 @@ AI 生成フローの中で人間が用意する成果物と、その管理場�
 - [mavlink](api/mavlink/api_mavlink.md)
 
 # テスト仕様
-- [comm](test/comm)
+ - [comm](test/comm)
+ - [mavlink](test/mavlink)
 

--- a/docs/test/mavlink/test_read_message.md
+++ b/docs/test/mavlink/test_read_message.md
@@ -1,0 +1,44 @@
+# テスト仕様書
+
+## IMavLinkService::readMessage
+- 新しいメッセージを受信できること ... TEST001
+- 受信バッファにメッセージがない場合にエラーとなること ... TEST002
+- startService()を呼び出していない状態でreadMessage()を実行した場合にエラーとなること ... TEST003
+
+---
+
+### テストケース詳細
+
+#### TEST001
+- **概要**: 受信バッファにあるメッセージを正しく取得できることを確認する
+- **条件**:
+  - サービスはstartService()で開始済み
+  - 送信側からHEARTBEATメッセージが送信されている
+  - is_dirty: 変数参照を渡す
+- **期待される結果**:
+  - 戻り値: true
+  - message.typeがMavlinkMsgType::HEARTBEATであること
+  - is_dirtyがtrueとなること
+
+---
+
+#### TEST002
+- **概要**: 受信バッファにメッセージがない場合の挙動を確認する
+- **条件**:
+  - サービスはstartService()で開始済み
+  - 送信側からメッセージは送られていない
+  - is_dirty: 変数参照を渡す
+- **期待される結果**:
+  - 戻り値: false
+  - is_dirtyがfalseとなること
+
+---
+
+#### TEST003
+- **概要**: startService()を呼び出していない状態でreadMessage()を実行した場合のエラー処理を確認する
+- **条件**:
+  - startService()は未呼び出し
+  - is_dirty: 変数参照を渡す
+- **期待される結果**:
+  - 戻り値: false
+  - メッセージは取得されないこと

--- a/docs/test/mavlink/test_send_message.md
+++ b/docs/test/mavlink/test_send_message.md
@@ -1,0 +1,54 @@
+# テスト仕様書
+
+## IMavLinkService::sendMessage
+- 有効なMavlinkHakoMessageを送信できること ... TEST001
+- MavlinkHakoMessage.typeにUNKNOWNを指定した場合にエラーとなること ... TEST002
+- startService()を呼び出さずに送信した場合にエラーとなること ... TEST003
+- ネットワークエラー発生時に送信失敗となること ... TEST004
+
+---
+
+### テストケース詳細
+
+#### TEST001
+- **概要**: HEARTBEATメッセージを指定して正常に送信できることを確認する
+- **条件**:
+  - message.type: MavlinkMsgType::HEARTBEAT
+  - サービスはstartService()で開始済み
+- **期待される結果**:
+  - 戻り値: true
+  - 送信先にメッセージが到達すること
+
+---
+
+#### TEST002
+- **概要**: MavlinkHakoMessage.typeにUNKNOWNを指定した場合のエラー処理を確認する
+- **条件**:
+  - message.type: MavlinkMsgType::UNKNOWN
+  - サービスはstartService()で開始済み
+- **期待される結果**:
+  - 戻り値: false
+  - メッセージは送信されないこと
+
+---
+
+#### TEST003
+- **概要**: startService()を呼び出さずにsendMessage()を実行した場合のエラー処理を確認する
+- **条件**:
+  - message.type: MavlinkMsgType::HEARTBEAT
+  - startService()は未呼び出し
+- **期待される結果**:
+  - 戻り値: false
+  - メッセージは送信されないこと
+
+---
+
+#### TEST004
+- **概要**: 送信途中でネットワークエラーが発生した場合の挙動を確認する
+- **条件**:
+  - message.type: MavlinkMsgType::HEARTBEAT
+  - サービスはstartService()で開始済み
+  - 送信先との通信を遮断する
+- **期待される結果**:
+  - 戻り値: false
+  - エラーログが出力されること


### PR DESCRIPTION
## Summary
- document Mavlink test cases for `sendMessage` and `readMessage`
- link new Mavlink test folder in docs README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868c246e6688322a2d50a304f851e78