### PR TITLE
Update comm API docs for blocking behavior

### DIFF
--- a/docs/api/comm/client/api_comm_client.md
+++ b/docs/api/comm/client/api_comm_client.md
@@ -92,6 +92,9 @@ std::shared_ptr<ICommIO> client_open(ICommEndpointType *src, ICommEndpointType *
 
 - 送信元および送信先のエンドポイントが無効である場合、本関数は `nullptr` を返します。
 - 戻り値が `nullptr` の場合は適切なエラーハンドリングを実装してください。
+- **通信方式によるブロック動作の違い**
+  - **TCP**: `client_open()` はサーバとの接続が確立するまでブロックします。
+  - **UDP**: ソケット初期化後ただちに復帰します。
 
 ---
 

--- a/docs/api/comm/io/api_comm_io.md
+++ b/docs/api/comm/io/api_comm_io.md
@@ -98,6 +98,9 @@ bool recv(char* data, int datalen, int* recv_datalen) = 0;
 - UDP の場合、データ到達保証はありません。
 - 受信データが `datalen` を超える場合、超過分は破棄されます。
 - `recv_datalen` を `NULL` にした場合、受信は行われますが受信バイト数は返されません。
+- **ブロック動作の違い**
+  - **TCP**: `recv()` は指定された `datalen` バイトを受信するまでブロックします。
+  - **UDP**: 1 データグラム受信時点で復帰し、`datalen` より小さい長さで返る場合があります。
 
 ---
 

--- a/docs/api/comm/server/api_comm_server.md
+++ b/docs/api/comm/server/api_comm_server.md
@@ -91,6 +91,9 @@ std::shared_ptr<ICommIO> server_open(ICommEndpointType *endpoint) = 0;
 
 - エンドポイントが無効である場合、本関数は `nullptr` を返します。
 - 戻り値が `nullptr` の場合は適切なエラーハンドリングを実装してください。
+- **通信方式によるブロック動作の違い**
+  - **TCP**: `server_open()` はクライアントからの接続が確立するまでブロックします。
+  - **UDP**: `server_open()` はソケットを準備したあと即座に復帰します。最初のパケット待ち合わせは `recv()` で行います。
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify blocking behavior for `server_open`, `client_open` and `recv`
- document difference between TCP and UDP

## Testing
- `bash tools/build_and_test.sh` *(fails: comm_recv_tcp segfault)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb24162c8322aabb4d015aa77be1